### PR TITLE
Fix log generator not found for sln consuming IDEs

### DIFF
--- a/MetaMystia.sln
+++ b/MetaMystia.sln
@@ -1,8 +1,10 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.0.11217.181 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetaMystia", "MetaMystia.csproj", "{B4CD19DA-EE08-5225-FB19-1D0DFA4113DD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LogGenerator", "LogGenerator\LogGenerator.csproj", "{2B487D42-7871-44B4-81FF-8035896B3700}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,6 +16,10 @@ Global
 		{B4CD19DA-EE08-5225-FB19-1D0DFA4113DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4CD19DA-EE08-5225-FB19-1D0DFA4113DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4CD19DA-EE08-5225-FB19-1D0DFA4113DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B487D42-7871-44B4-81FF-8035896B3700}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B487D42-7871-44B4-81FF-8035896B3700}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B487D42-7871-44B4-81FF-8035896B3700}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B487D42-7871-44B4-81FF-8035896B3700}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
sln-consuming .Net IDEs expect all sub project a project references also exists inside the sln file, this PR fixes the issue where the LogGenerator is reported missing when building the MetaMystia with VisualStudio or Jetbrains Rider