### PR TITLE
Update language version to C# 14

### DIFF
--- a/MetaMystia.csproj
+++ b/MetaMystia.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>14</LangVersion>
     <AssemblyName>MetaMystia</AssemblyName>
     <Product>MetaMystia</Product>
     <Version>0.9.4</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
     <RestoreAdditionalProjectSources>
       https://api.nuget.org/v3/index.json;
       https://nuget.bepinex.dev/v3/index.json
@@ -64,7 +64,7 @@
     <PackageReference Include="Costura.Fody" Version="6.*">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Fody" Version="6.*">
+    <PackageReference Include="Fody" Version="6.9.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="MemoryPack" Version="1.21.4">

--- a/Network/Actions/NetAction.cs
+++ b/Network/Actions/NetAction.cs
@@ -123,8 +123,7 @@ public abstract partial class NetAction
 
     public static void RegisterAllFormatter()
     {
-        NetAction.RegisterFormatter();
-        GuestServeAction.RegisterFormatter();
-        GuestLeaveAction.RegisterFormatter();
+        if (!MemoryPackFormatterProvider.IsRegistered<NetAction>()) MemoryPackFormatterProvider.Register(new NetActionFormatter());
+        if (!MemoryPackFormatterProvider.IsRegistered<NetAction[]>()) MemoryPackFormatterProvider.Register(new MemoryPack.Formatters.ArrayFormatter<NetAction>());
     }
 }

--- a/Utils/SgrYukiUtils.cs
+++ b/Utils/SgrYukiUtils.cs
@@ -140,10 +140,8 @@ public static class Extensions
         this Il2CppSystem.Collections.Generic.Dictionary<KeyT, ValueT> dict, Predicate<ValueT> condition)
     {
         var result = new System.Collections.Generic.List<KeyT>();
-        var e = dict.GetEnumerator();
-        while (e.MoveNext())
+        foreach (var kv in dict)
         {
-            var kv = e.Current;
             if (condition(kv.Value)) result.Add(kv.Key);
         }
         return result;


### PR DESCRIPTION
While the BepInEX only supports targeting Net 6, we can still upgrade the language version to C# 14, which offers more [syntax features](https://learn.microsoft.com/zh-cn/dotnet/csharp/whats-new/csharp-14).

> [!WARNING]
> You need to install .Net SDK 10.0 for the project to compile
