### PR TITLE
fix(skin): correct typo of Komeiji sisters

### DIFF
--- a/Players/PlayerSkin.cs
+++ b/Players/PlayerSkin.cs
@@ -318,9 +318,22 @@ public partial class PlayerSkin
         var table = new StringBuilder();
         foreach (var skin in ListAllSkins())
         {
-            table.AppendLine($"{skin.name}: {skin.skin.CharacterId} {skin.skin.SelectedType} {skin.skin.SkinIndex}");
+            var displayName = GetSkinDisplayName(skin.skin.CharacterId, skin.name);
+            table.AppendLine($"{displayName}: {skin.skin.CharacterId} {skin.skin.SelectedType} {skin.skin.SkinIndex}");
         }
         return table.ToString();
+    }
+
+    // The base game's built-in skin asset names contain two Chinese typos.
+    // Keep the correction local to `/skin list` instead of mutating shared assets.
+    private static string GetSkinDisplayName(int characterId, string name)
+    {
+        return (characterId, name) switch
+        {
+            (2003, "古地名觉") => "古明地觉",
+            (2006, "古地名恋") => "古明地恋",
+            _ => name
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
尝试解决 https://github.com/MetaMystia/MetaMystia/issues/88 中提到的问题。
古明地变成了古地名，怎么回事呢？
预期效果：
<img width="766" height="201" alt="image" src="https://github.com/user-attachments/assets/34cdd509-d4ea-484f-a5af-c10e24fd04a3" />
